### PR TITLE
Add User Subscription Insertion to Database - BEHROUZ - #50

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 
+import db from "./db.js";
 import { lookupEmail } from "./functions/lookupEmail.js";
 import messageRouter from "./messages/messageRouter.js";
 
@@ -17,7 +18,21 @@ api.post("/subscribe", async (req, res) => {
 		const user = await lookupEmail(email);
 
 		if (user.ok) {
-			// @todo Insert users data into DB here...
+			// Check if the user is already subscribed
+			const existingUser = await db.query(
+				"SELECT * FROM subscriptions WHERE email = $1",
+				[email],
+			);
+
+			if (existingUser.rowCount > 0) {
+				return res.redirect("/subscribe/error?status=duplicate");
+			}
+
+			// Insert user into the database
+			await db.query(
+				"INSERT INTO subscriptions (email, created_at) VALUES ($1, NOW())",
+				[email],
+			);
 
 			res.redirect("/subscribe/confirmation");
 		}


### PR DESCRIPTION

## Description

Currently, the /subscribe endpoint verifies the user's email but does not insert the user into the database. We need to:

Check if the user is already subscribed by querying the subscriptions table.
Insert the user into the database if they are not already subscribed.
Ensure proper error handling for duplicate subscriptions and database failures.
Return appropriate responses

## Related to

Fixes #50 
