### PR TITLE
Implement Rate Limit Handling for Slack Web API Requests - BEHROUZ - #58

### DIFF
--- a/api/utils/throttling.js
+++ b/api/utils/throttling.js
@@ -1,0 +1,16 @@
+// utils/throttling.js
+export async function callWithRetry(apiCall, args, retries = 5) {
+	try {
+		return await apiCall(args);
+	} catch (error) {
+		if (error.data && error.data.retry_after) {
+			const retryAfter = error.data.retry_after * 1000; // Convert seconds to ms
+			await new Promise((resolve) => setTimeout(resolve, retryAfter));
+			return callWithRetry(apiCall, args, retries - 1);
+		}
+		if (retries > 0) {
+			return callWithRetry(apiCall, args, retries - 1);
+		}
+		throw error;
+	}
+}


### PR DESCRIPTION

## Description

This PR adds a throttling function that manages requests to the Slack Web API efficiently. When a request exceeds the rate limit, the function catches the error, waits for the specified retry period, and then automatically retries the request. This ensures smoother handling of rate limits and reduces the risk of failed API calls.

## Related to

Fixes #58 
