### PR TITLE
Adding empty function definitions and failing tests

### DIFF
--- a/api/functions/decideScore.js
+++ b/api/functions/decideScore.js
@@ -1,0 +1,13 @@
+import logger from "../utils/logger.js";
+
+/**
+ * Decides a score for a userbased on the number of messages and reactions
+ * @param {number} messages - The number of messages
+ * @param {number} reactions - The number of reactions
+ * @returns {number} The score
+ */
+export const decideScore = ({ messages, reactions }) => {
+	// @todo: Implement the logic to decide the score
+	logger.debug(messages, reactions);
+	return 50;
+};

--- a/api/functions/decideScore.test.js
+++ b/api/functions/decideScore.test.js
@@ -1,0 +1,50 @@
+import { decideScore } from "./decideScore.js";
+
+// @todo: Implement the decideScore function and unskip these tests
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip("decideScore", () => {
+	it("should return 50 when there are 3 message and 4 reactions", () => {
+		const score = decideScore({ messages: 3, reactions: 4 });
+		expect(score).toBe(50);
+	});
+
+	it("should return 100 when there are 22 messages and 3 reactions", () => {
+		const score = decideScore({ messages: 22, reactions: 3 });
+		expect(score).toBe(100);
+	});
+
+	it("should handle when there are no messages", () => {
+		const score = decideScore({ messages: 0, reactions: 3 });
+		expect(score).toBe(44);
+	});
+
+	it("should handle when there are no reactions", () => {
+		const score = decideScore({ messages: 22, reactions: 0 });
+		expect(score).toBe(56);
+	});
+
+	it("should handle when there are no messages and no reactions", () => {
+		const score = decideScore({ messages: 0, reactions: 0 });
+		expect(score).toBe(0);
+	});
+
+	it("should handle when messages and reactions are negative", () => {
+		const score = decideScore({ messages: -1, reactions: -1 });
+		expect(score).toBe(0);
+	});
+
+	it("should handle when messages and reactions are null or undefined", () => {
+		const score = decideScore({ messages: null, reactions: undefined });
+		expect(score).toBe(0);
+	});
+
+	it("should handle when only messages are provided", () => {
+		const score = decideScore({ reactions: 4 });
+		expect(score).toBe(4);
+	});
+
+	it("should handle if reactions are not provided", () => {
+		const score = decideScore({ messages: 3 });
+		expect(score).toBe(13);
+	});
+});

--- a/api/functions/updateCounts.js
+++ b/api/functions/updateCounts.js
@@ -1,0 +1,32 @@
+import logger from "../utils/logger.js";
+
+/**
+ * Updates the counts object with the messages and reactions from the slack data
+ * @param {Object} counts - The counts object
+ * @param {Object} slackData - The slack data
+ * @returns {Object} The updated counts object
+ */
+export const updateCounts = ({ counts, slackData }) => {
+	logger.debug(counts, slackData);
+	// @todo Implement this function
+	return {
+		"01-02-2025": {
+			U1234: {
+				messages: 12,
+				reactions: 22,
+			},
+			U5678: {
+				messages: 3,
+			},
+		},
+		"02-02-2025": {
+			U1234: {
+				messages: 33,
+				reactions: 45,
+			},
+			U5678: {
+				reactions: 11,
+			},
+		},
+	};
+};

--- a/api/functions/updateCounts.test.js
+++ b/api/functions/updateCounts.test.js
@@ -1,0 +1,156 @@
+import { updateCounts } from "./updateCounts";
+
+// @todo: Implement the updateCounts function and unskip these tests
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip("updateCounts", () => {
+	it("initiliases the counts object if it isn't provided", () => {
+		const result = updateCounts({ counts: undefined, slackData: [] });
+		expect(result).toBe({});
+	});
+
+	it("returns the counts object provided if no slack data is provided", () => {
+		const result = updateCounts({
+			counts: { "01-02-2025": {} },
+			slackData: [],
+		});
+		expect(result).toBe({ "01-02-2025": {} });
+	});
+
+	it("updates the counts object with the messages and reactions from the slack data", () => {
+		const result = updateCounts({
+			counts: { "01-02-2025": {} },
+			slackData: [
+				{
+					ts: "1714000000",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+						{
+							name: "facepalm",
+							count: 2,
+							users: ["U1234", "U5678"],
+						},
+					],
+					user: "U1234",
+				},
+			],
+		});
+		expect(result).toBe({
+			"01-02-2025": { U1234: { messages: 1, reactions: 1 } },
+		});
+	});
+
+	it("handles multiple messages from the same user on the same day", () => {
+		const result = updateCounts({
+			counts: { "01-02-2025": {} },
+			slackData: [
+				{
+					ts: "1714000000",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+						{
+							name: "facepalm",
+							count: 2,
+							users: ["U1234", "U5678"],
+						},
+					],
+					user: "U1234",
+				},
+				{
+					ts: "1714000000",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+						{
+							name: "facepalm",
+							count: 2,
+							users: ["U1234", "U5678"],
+						},
+					],
+					user: "U1234",
+				},
+			],
+		});
+		expect(result).toBe({
+			"01-02-2025": { U1234: { messages: 2, reactions: 2 } },
+		});
+	});
+
+	it("handles multiple messages from different users on the same day", () => {
+		const result = updateCounts({
+			counts: { "01-02-2025": {} },
+			slackData: [
+				{
+					ts: "1714000000",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+						{
+							name: "facepalm",
+							count: 2,
+							users: ["U1234", "U5678"],
+						},
+					],
+					user: "U1234",
+				},
+				{
+					ts: "1714000000",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+						{
+							name: "facepalm",
+							count: 2,
+							users: ["U1234", "U5678"],
+						},
+					],
+					user: "U5678",
+				},
+			],
+		});
+		expect(result).toBe({
+			"01-02-2025": {
+				U1234: { messages: 1, reactions: 1 },
+				U5678: { messages: 1, reactions: 1 },
+			},
+		});
+	});
+
+	it("resets the data for a particulr day if an entry already exists for that day", () => {
+		const result = updateCounts({
+			counts: { "01-02-2025": { U1234: { messages: 5, reactions: 10 } } },
+			slackData: [
+				{
+					ts: "1714000000",
+					user: "U1234",
+					reactions: [
+						{
+							name: "astonished",
+							count: 1,
+							users: ["U1234"],
+						},
+					],
+				},
+			],
+		});
+		expect(result).toBe({
+			"01-02-2025": { U1234: { messages: 1, reactions: 1 } },
+		});
+	});
+});


### PR DESCRIPTION
## What?
This PR adds two empty function definitions and some associated failing tests for these functions

`decideScore` & `updateCounts`

## Why?
To communicate the structure for these functions and to make a start on some jest tests to demonstrate how they should work

## Next steps
Tickets #77 & #81 cover the work to actually implement these functions. This PR simply created a framework for this work