### PR TITLE
#66 - Align Components at Subscribe page with Figma Design - Jordan

### DIFF
--- a/web/src/components/SubscriptionFormHTML.css
+++ b/web/src/components/SubscriptionFormHTML.css
@@ -1,0 +1,18 @@
+.subscription-form__container {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.subscription-form__layout {
+	display: flex;
+	flex-direction: row;
+	gap: 16px;
+	width: 100%;
+}
+
+@media screen and (max-width: 768px) {
+	.subscription-form__layout {
+		flex-direction: column;
+		align-items: center;
+	}
+}

--- a/web/src/components/SubscriptionFormHTML.jsx
+++ b/web/src/components/SubscriptionFormHTML.jsx
@@ -1,20 +1,30 @@
-import { Button, Input, Space } from "antd";
+import { Typography } from "antd";
+
+import { ThemedButton } from "./ThemedButton";
+import { ThemedInput } from "./ThemedInput";
+
+import "./SubscriptionFormHTML.css";
 
 const SubscriptionFormHTML = () => {
 	return (
-		<div>
+		<div className="subscription-form__container">
 			<form action="/api/subscribe" method="post" id="subscription-form">
-				<Space.Compact>
-					<Input
+				<div className="subscription-form__layout">
+					<ThemedInput
 						type="email"
 						name="email"
-						placeholder="Enter your email"
+						placeholder="Enter your email linked to CYF Slack"
 						required
 					/>
-					<Button type="primary" htmlType="submit">
-						Subscribe
-					</Button>
-				</Space.Compact>
+					<ThemedButton type="primary" htmlType="submit">
+						<Typography.Title
+							level={5}
+							style={{ color: "#fff", fontStyle: "italic" }}
+						>
+							Subscribe
+						</Typography.Title>
+					</ThemedButton>
+				</div>
 			</form>
 		</div>
 	);

--- a/web/src/components/ThemedButton.css
+++ b/web/src/components/ThemedButton.css
@@ -1,0 +1,25 @@
+.themed-button {
+	height: 40px;
+	border-radius: 2px !important;
+	border-width: 1px !important;
+	padding: 6.4px 15px !important;
+	gap: 10px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+	line-height: 24px;
+}
+
+/* Override antd's default border-radius */
+.themed-button.ant-btn {
+	border-radius: 2px;
+}
+
+/* Ensure hover states don't change the dimensions */
+.themed-button:hover,
+.themed-button:focus,
+.themed-button:active {
+	height: 40px;
+	border-radius: 2px;
+}

--- a/web/src/components/ThemedButton.jsx
+++ b/web/src/components/ThemedButton.jsx
@@ -1,0 +1,19 @@
+import { Button } from "antd";
+import { forwardRef } from "react";
+
+import "./ThemedButton.css";
+
+// eslint-disable-next-line react/prop-types
+export const ThemedButton = forwardRef(({ className, ...props }, ref) => {
+	return (
+		<Button
+			type="primary"
+			size="large"
+			className={`themed-button ${className || ""}`}
+			ref={ref}
+			{...props}
+		/>
+	);
+});
+
+ThemedButton.displayName = "ThemedButton";

--- a/web/src/components/ThemedInput.css
+++ b/web/src/components/ThemedInput.css
@@ -1,0 +1,27 @@
+.input-container {
+	box-sizing: border-box;
+	position: relative;
+	width: 100%;
+	height: 40px;
+	flex: 1;
+	padding: 0;
+}
+
+.themed-input {
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	padding: 8px 12px;
+	font-size: 16px;
+	border: 1px solid #d9d9d9;
+	border-radius: 2px;
+}
+
+.themed-input::placeholder {
+	color: #bfbfbf;
+}
+
+.themed-input:focus {
+	outline: none;
+	border-color: #1890ff;
+}

--- a/web/src/components/ThemedInput.jsx
+++ b/web/src/components/ThemedInput.jsx
@@ -1,0 +1,15 @@
+import { Input } from "antd";
+import { forwardRef } from "react";
+
+import "./ThemedInput.css";
+
+// eslint-disable-next-line react/prop-types
+export const ThemedInput = forwardRef(({ className, ...props }, ref) => {
+	return (
+		<div className={`input-container ${className || ""}`}>
+			<Input ref={ref} className="themed-input" {...props} />
+		</div>
+	);
+});
+
+ThemedInput.displayName = "ThemedInput";

--- a/web/src/pages/Subscribe.jsx
+++ b/web/src/pages/Subscribe.jsx
@@ -36,7 +36,7 @@ function Subscribe() {
 					</Typography.Title>
 				</Flex>
 
-				<Flex vertical gap={24}>
+				<Flex vertical gap={24} style={{ width: "100%" }}>
 					<SubscriptionFormHTML />
 					<Typography.Paragraph
 						type="secondary"


### PR DESCRIPTION
## Description

- Created `ThemedButton` and `ThemedInput` components that wrap Ant Design components with consistent styling
- Replaced standard Ant Design components with our new themed versions in `SubscriptionFormHTML`
- Added responsive layout with proper flex direction for mobile devices
- Updated placeholder text for email input (`Enter your email linked to CYF Slack`)
- Improved button styling with proper typography and italic styling for the `Subscribe` text

## Related to

Fixes #66 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have carefully reviewed my own code
- [x] I have commented my code
- [ ] I have updated any documentation
