### PR TITLE
correct local url replaced - BEHROUZ - #93

### DIFF
--- a/web/src/pages/Upload.jsx
+++ b/web/src/pages/Upload.jsx
@@ -21,7 +21,7 @@ export const FileUploading = () => {
 
 		setUploading(true);
 
-		fetch("https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload", {
+		fetch("http://localhost:3000/api/upload/api/upload", {
 			method: "POST",
 			body: formData,
 		})


### PR DESCRIPTION

## Description

The URL used in the fetch function on the upload page is incorrect and should be replaced with the local server URL.

## Related to

Fixes #93

