### PR TITLE
Remove channel Column from slack_user_activity Migration - BEHROUZ -  #102

### DIFF
--- a/api/migrations/1741620323646_users-activity.cjs
+++ b/api/migrations/1741620323646_users-activity.cjs
@@ -12,7 +12,6 @@ const migration = {
 	up(pgm) {
 		pgm.createTable("slack_user_activity", {
 			id: { type: "serial", primaryKey: true },
-			channel: { type: "text", notNull: true },
 			date: { type: "date", notNull: true },
 			user_id: {
 				type: "text",


### PR DESCRIPTION

## Description

The current migration for the slack_user_activity table includes a channel column, which is no longer required. This change will remove the channel column from the migration file. This PR deletes the channel column from the database.

## Related to

Fixes #102
