### PR TITLE
CREATE A CONFIG TABLE - BEHROUZ - #95

### DIFF
--- a/api/migrations/1742567703143_config-table.cjs
+++ b/api/migrations/1742567703143_config-table.cjs
@@ -1,0 +1,33 @@
+/**
+ * Template for
+ * {@link https://salsita.github.io/node-pg-migrate/#/migrations?id=defining-migrations defining migrations}.
+ *
+ * @type {{
+ *   down: (pgm: import("node-pg-migrate").MigrationBuilder) => void | Promise<void>;
+ *   shorthands: Record<string, import("node-pg-migrate").ColumnDefinition>;
+ *   up: (pgm: import("node-pg-migrate").MigrationBuilder) => void | Promise<void>;
+ * }}
+ */
+const migration = {
+	up(pgm) {
+		pgm.createTable("config_table", {
+			id: { type: "serial", primaryKey: true },
+			low_threshold: { type: "integer", notNull: true, default: 1 },
+			medium_threshold: { type: "integer", notNull: true, default: 5 },
+			high_threshold: { type: "integer", notNull: true, default: 10 },
+			message_weighting: { type: "float", notNull: true, default: 3 },
+			reactions_weighting: { type: "float", notNull: true, default: 1 },
+			reactions_received_weighting: {
+				type: "float",
+				notNull: true,
+				default: 1,
+			},
+		});
+	},
+	down(pgm) {
+		pgm.dropTable("config_table");
+	},
+	shorthands: undefined,
+};
+
+module.exports = migration;


### PR DESCRIPTION

## Description

It creates a migration file for the config table, which stores data used to determine a user's status—whether they are low, medium, or highly active. It also includes weightings for messages and reactions, allowing admins to assign different weights to each type of activity.

## Related to

Fixes #95
