### PR TITLE
Decide score should read weights - BEHROUZ -#101

### DIFF
--- a/api/functions/decideScore.js
+++ b/api/functions/decideScore.js
@@ -31,24 +31,19 @@ export const decideScore = ({
 	if (!Number.isFinite(reactions)) reactions = 0;
 	if (!Number.isFinite(reactionsReceived)) reactionsReceived = 0;
 
-	if (messages > 0 && reactions > 0) {
-		return (
-			messageWeight * messages +
-			reactionWeight * reactions +
-			reactionsReceivedWeight * reactionsReceived
-		);
-	}
-
 	if (messages <= 0 && reactions <= 0) return 0;
 
-	// If there are no messages, ignore reactionsReceived.
-	if (!messages) {
-		return reactionWeight * reactions;
-	}
+	// if no messages then no reactions received.
+	if (!messages) return reactionWeight * reactions;
 
-	if (!reactions) {
+	if (!reactions)
 		return (
 			messageWeight * messages + reactionsReceivedWeight * reactionsReceived
 		);
-	}
+
+	return (
+		messageWeight * messages +
+		reactionWeight * reactions +
+		reactionsReceivedWeight * reactionsReceived
+	);
 };

--- a/api/functions/decideScore.js
+++ b/api/functions/decideScore.js
@@ -1,23 +1,54 @@
 /**
- * Calculates a user score based on activity, considering both messages and reactions that are sent.
+ * Calculates a user score based on activity, considering messages, reactions, and reactions received.
  *
- * The score is determined by a weighted combination of the number of messages and reactions.
- * This helps measure engagement, where reactions may indicate higher interaction quality.
+ * The score is determined by a weighted combination of the number of messages, reactions, and reactions received.
+ * This helps measure engagement, where reactions and reactions received may indicate higher interaction quality.
  *
- * @param {number} messages - The number of messages sent by the user.
- * @param {number} reactions - The number of reactions received on messages.
+ * @param {Object} params - The parameters for calculating the score.
+ * @param {number} params.messages - The number of messages sent by the user.
+ * @param {number} params.reactions - The number of reactions received on messages.
+ * @param {number} params.reactionsReceived - The number of reactions the user has received on their messages.
+ * @param {number} [params.messageWeight=3] - The weight applied to the number of messages.
+ * @param {number} [params.reactionWeight=1] - The weight applied to the number of reactions.
+ * @param {number} [params.reactionsReceivedWeight=1] - The weight applied to the number of reactions received.
+ *
  * @returns {number} The calculated engagement score.
+ *   - If both messages and reactions are greater than 0, the score is calculated as:
+ *     `messageWeight * messages + reactionWeight * reactions + reactionsReceivedWeight * reactionsReceived`
+ *   - If only messages are provided, the score is calculated as `messageWeight * messages + reactionsReceivedWeight * reactionsReceived`.
+ *   - If only reactions are provided, the score is calculated as `reactionWeight * reactions`.
+ *   - If no valid messages or reactions are provided, the score will be 0.
  */
-
-export const decideScore = ({ messages, reactions }) => {
+export const decideScore = ({
+	messages,
+	reactions,
+	reactionsReceived,
+	messageWeight = 3,
+	reactionWeight = 1,
+	reactionsReceivedWeight = 1,
+}) => {
 	if (!Number.isFinite(messages)) messages = 0;
 	if (!Number.isFinite(reactions)) reactions = 0;
+	if (!Number.isFinite(reactionsReceived)) reactionsReceived = 0;
 
-	if (messages > 0 && reactions > 0) return messages * 3 + reactions;
+	if (messages > 0 && reactions > 0) {
+		return (
+			messageWeight * messages +
+			reactionWeight * reactions +
+			reactionsReceivedWeight * reactionsReceived
+		);
+	}
 
 	if (messages <= 0 && reactions <= 0) return 0;
 
-	if (!messages) return reactions;
+	// If there are no messages, ignore reactionsReceived.
+	if (!messages) {
+		return reactionWeight * reactions;
+	}
 
-	if (!reactions) return messages * 3;
+	if (!reactions) {
+		return (
+			messageWeight * messages + reactionsReceivedWeight * reactionsReceived
+		);
+	}
 };

--- a/api/functions/decideScore.test.js
+++ b/api/functions/decideScore.test.js
@@ -6,28 +6,36 @@ describe("decideScore", () => {
 		expect(score).toBe(0);
 	});
 
-	it("should return 50 when there are 3 message and 4 reactions", () => {
+	it("should return 13 when there are 3 messages and 4 reactions", () => {
 		const score = decideScore({ messages: 3, reactions: 4 });
 		expect(score).toBe(13);
 	});
 
-	it("should return 100 when there are 22 messages and 3 reactions", () => {
+	it("should return 69 when there are 22 messages and 3 reactions", () => {
 		const score = decideScore({ messages: 22, reactions: 3 });
 		expect(score).toBe(69);
 	});
 
-	it("should handle when there are no messages", () => {
-		const score = decideScore({ messages: 0, reactions: 3 });
-		expect(score).toBe(3);
+	it("should return 30 when there are 10 messages and 10 reactions and reactionsReceived = 5", () => {
+		const score = decideScore({
+			messages: 10,
+			reactions: 10,
+			reactionsReceived: 5,
+		});
+		expect(score).toBe(45);
 	});
 
-	it("should handle when there are no reactions", () => {
-		const score = decideScore({ messages: 22, reactions: 0 });
-		expect(score).toBe(66);
-	});
-
-	it("should handle when there are no messages and no reactions", () => {
+	it("should handle when there are no messages and reactions", () => {
 		const score = decideScore({ messages: 0, reactions: 0 });
+		expect(score).toBe(0);
+	});
+
+	it("should return score based on reactionsReceived when no messages and no reactions", () => {
+		const score = decideScore({
+			messages: 0,
+			reactions: 0,
+			reactionsReceived: 0,
+		});
 		expect(score).toBe(0);
 	});
 
@@ -42,12 +50,81 @@ describe("decideScore", () => {
 	});
 
 	it("should handle when only messages are provided", () => {
-		const score = decideScore({ reactions: 4 });
-		expect(score).toBe(4);
+		const score = decideScore({ messages: 3 });
+		expect(score).toBe(9);
 	});
 
 	it("should handle if reactions are not provided", () => {
-		const score = decideScore({ messages: 3 });
-		expect(score).toBe(9);
+		const score = decideScore({ messages: 3, reactionsReceived: 5 });
+		expect(score).toBe(14);
+	});
+
+	it("should handle when only reactions are provided", () => {
+		const score = decideScore({ reactions: 3 });
+		expect(score).toBe(3);
+	});
+
+	it("should handle when reactionsReceived are provided but no messages", () => {
+		const score = decideScore({ reactionsReceived: 4 });
+		expect(score).toBe(0);
+	});
+
+	it("should return the correct weighted score when weighting parameters are customized", () => {
+		const score = decideScore({
+			messages: 5,
+			reactions: 2,
+			reactionsReceived: 3,
+			messageWeight: 4,
+			reactionWeight: 2,
+			reactionsReceivedWeight: 1,
+		});
+		expect(score).toBe(27); // (4*5 + 2*2 + 1*3)
+	});
+
+	it("should return the correct weighted score when only reactionWeight is customized", () => {
+		const score = decideScore({
+			messages: 5,
+			reactions: 2,
+			reactionsReceived: 3,
+			messageWeight: 3, // Only messageWeight customized
+		});
+		expect(score).toBe(20); // (3*5 + 1*2 + 1*3)
+	});
+
+	it("should return the correct weighted score when only reactionsReceivedWeight is customized", () => {
+		const score = decideScore({
+			messages: 5,
+			reactions: 2,
+			reactionsReceived: 3,
+			reactionWeight: 2, // Only reactionsWeight customized
+		});
+		expect(score).toBe(22); // (3*5 + 2*2 + 1*3)
+	});
+
+	it("should return the correct weighted score when only messages and reactions are provided", () => {
+		const score = decideScore({
+			messages: 5,
+			reactions: 2,
+			// Default weights will be used: messageWeight=3, reactionWeight=1, reactionsReceivedWeight=1
+		});
+		expect(score).toBe(17); // (3*5 + 1*2 + 1*0)
+	});
+
+	it("should return the correct weighted score when only messages and reactionsReceived are provided", () => {
+		const score = decideScore({
+			messages: 5,
+			reactionsReceived: 3,
+			// Default weights will be used: messageWeight=3, reactionWeight=1, reactionsReceivedWeight=1
+		});
+		expect(score).toBe(18); // (3*5 + 1*0 + 1*3)
+	});
+
+	it("should return the correct weighted score when only reactions and reactionsReceived are provided", () => {
+		const score = decideScore({
+			reactions: 2,
+			reactionsReceived: 3,
+			// Default weights will be used: messageWeight=3, reactionWeight=1, reactionsReceivedWeight=1
+		});
+		expect(score).toBe(2); // ( 1*2) When messages is not provided reactionsReceived is ignored
 	});
 });

--- a/api/functions/decideScore.test.js
+++ b/api/functions/decideScore.test.js
@@ -16,7 +16,7 @@ describe("decideScore", () => {
 		expect(score).toBe(69);
 	});
 
-	it("should return 30 when there are 10 messages and 10 reactions and reactionsReceived = 5", () => {
+	it("should return 45 when there are 10 messages and 10 reactions and reactionsReceived = 5", () => {
 		const score = decideScore({
 			messages: 10,
 			reactions: 10,
@@ -34,7 +34,7 @@ describe("decideScore", () => {
 		const score = decideScore({
 			messages: 0,
 			reactions: 0,
-			reactionsReceived: 0,
+			reactionsReceived: Math.floor(Math.random() * 10),
 		});
 		expect(score).toBe(0);
 	});


### PR DESCRIPTION
## Description
decideScore function updated to allow customizable weights for messages, reactions, and reactions received. Default weights are used if no custom values are provided. The function handles edge cases, such as missing or non-numeric inputs. Test cases have been updated to match the new version of the function.

## Related to

Fixes #101 
